### PR TITLE
Allow for custom success and cancel urls to be passed at checkout

### DIFF
--- a/src/api/schemas/checkouts.sdl.js
+++ b/src/api/schemas/checkouts.sdl.js
@@ -25,6 +25,6 @@ export const schema = `
   type Mutation {
     # In GraphQL, we can't reuse types as mutation inputs
     # (otherwise we'd just type "cart" as "[Product!]!")
-    checkout(cart: [ProductInput!]!): Session! @skipAuth
+    checkout(cart: [ProductInput!]!, cancelUrl: String, successUrl: String): Session! @skipAuth
   }
 `

--- a/src/api/services/checkouts/checkouts.js
+++ b/src/api/services/checkouts/checkouts.js
@@ -1,7 +1,7 @@
 import { stripe } from '../../lib'
 
-export const checkout = async ({cart}) => {
-  const { url, id } = await createStripeCheckoutSession(cart)
+export const checkout = async (payload) => {
+  const { url, id } = await createStripeCheckoutSession(payload)
  
   // api side redirect to Stripe Checkout (SUGGESTED APPROACH)
   // this approach is probably best put in a serverless function
@@ -14,7 +14,11 @@ export const checkout = async ({cart}) => {
 }
 
 
-export const createStripeCheckoutSession = async (cart) => {
+export const createStripeCheckoutSession = async ({
+  cart,
+  successUrl = "http://localhost:8910/stripe-demo?success=true&sessionId={CHECKOUT_SESSION_ID}",
+  cancelUrl = "http://localhost:8910/stripe-demo?success=false" }) => {
+
   const line_items = cart.map(product => ({
     price: product.id,
     quantity: product.quantity
@@ -23,8 +27,8 @@ export const createStripeCheckoutSession = async (cart) => {
   // TODO: Pass custom payload
   const session = await stripe.checkout.sessions.create({
     // See https://stripe.com/docs/payments/checkout/custom-success-page#modify-success-url.
-    success_url: `http://localhost:8910/success?sessionId={CHECKOUT_SESSION_ID}`,
-    cancel_url: `http://localhost:8910/failure`,
+    success_url: successUrl,
+    cancel_url: cancelUrl,
     // eslint-disable-next-line camelcase
     line_items: line_items,
     mode: 'payment',

--- a/src/web/hooks/index.js
+++ b/src/web/hooks/index.js
@@ -8,8 +8,10 @@ export const useCheckoutHandler = (cart) => {
     gql`
       mutation Checkout(
         $cart: [ProductInput!]!
+        $successUrl: String
+        $cancelUrl: String
       ) {
-        checkout(cart: $cart) {
+        checkout(cart: $cart, successUrl: $successUrl, cancelUrl: $cancelUrl) {
           id
           sessionUrl
         }
@@ -34,7 +36,7 @@ export const useCheckoutHandler = (cart) => {
   )
   */
  
-  return async (cart) => {
+  return async ({ cart, successUrl, cancelUrl }) => {
     const newCart = cart.map(item => ({id: item.id, quantity: item.quantity}))
     // Create checkout session and return session id
     const {
@@ -44,11 +46,16 @@ export const useCheckoutHandler = (cart) => {
           sessionUrl
         },
       },
-    } = await checkout({variables: {cart: newCart}})
+    } = await checkout({
+      variables: {
+        cart: newCart,
+        successUrl: successUrl,
+        cancelUrl: cancelUrl
+      }
+    })
 
     console.log(id, sessionUrl)
 
-   
     // APPROACH A
     // Redirect user to Stripe Checkout page
     // Not very secure, Server-side redirects are 


### PR DESCRIPTION
Let's pass `successUrl` and `cancelUrl` at  checkout to create checkout session. Defaults to localhost

```
await checkout({
      cart: cart,
      successUrl:
        'http://localhost:8910/stripe-demo?success=true&sessionId={CHECKOUT_SESSION_ID}',
      cancelUrl: 'http://localhost:8910/stripe-demo?success=false',
    })
```

closes #28 