### PR TITLE
feat: add basic CI (build)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,29 @@
+name: ⚙️ CI
+
+# The GitHub events we want this workflow to run in response to.
+# The hanging `pull_request:` may look odd, but all it does is say "run on every PR".
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  build:
+    name: 🔨 Build
+    runs-on: ubuntu-latest
+    steps:
+      # Checkout this repo on the GitHub runner.
+      # When the runner starts executing the jobs in this workflow,
+      # it literally doesn't even have the code in this repo yet.
+      - uses: actions/checkout@v3
+
+      # It doesn't have Node.js either; we have to set it up before we can do Node.js things. 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - run: yarn install
+        shell: bash
+
+      - name: 🔨 Build
+        run: yarn build


### PR DESCRIPTION
This PR adds basic CI for `yarn build`.

On every push to main or PR, this workflow file runs on a GitHub-hosted runner (right now it's ubuntu). There the package is built via `yarn build`. This way we'll know if a PR ever breaks the build.

After this I'll add others (lint, test, though test will certainly take more time than lint).

References for GitHub actions:

- The actions tab is here (you may have to enable actions): https://github.com/chrisvdm/redwoodjs-stripe/actions
-  The workflow file is written in Yaml. Yaml is a superset of JSON. See this reference: https://learnxinyminutes.com/docs/yaml/
- GitHub actions basics
  - There's some useful diagrams here for understanding terminology (workflow, jobs steps): https://docs.github.com/en/actions/using-workflows/about-workflows
  - Here's the essential reference for everything in a workflow file: https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions