### PR TITLE
Feat/new customer

### DIFF
--- a/src/api/schemas/customers.sdl.js
+++ b/src/api/schemas/customers.sdl.js
@@ -236,7 +236,89 @@ type StripeCashBalanceSettings {
     reconciliation_mode: String
 }
 
+input CreateStripeCustomerInput {
+    address: CreateStripeCustomerAddressInput
+    description: String
+    email: String
+    metadata: Metadata
+    name: String
+    payment_method: String
+    phone: String
+    shipping: CreateStripeCustomerShippingInput
+    balance: Int
+    cash_balance: CreateStripeCustomerCashBalanceInput
+    coupon: String
+    invoice_prefix: String
+    invoice_settings: CreateStripeCustomerInvoiceSettingsInput
+    next_invoice_sequence: String
+    preferred_locales: [String]
+    promotional_code: String
+    source: String
+    tax: CreateStripeCustomerTaxInput
+    tax_exempt: CreateStripeCustomerTaxExemptEnum
+    tax_id_data: [CreateStripeCustomerTaxIDDataInput]
+    test_clock: String
+}
+
+input CreateStripeCustomerTaxIDDataInput {
+    type: String!
+    value: Int!
+}
+
+enum CreateStripeCustomerTaxExemptEnum {
+    none
+    exempt
+    reverse
+}
+
+input CreateStripeCustomerTaxInput {
+    ip_address: String
+}
+
+input CreateStripeCustomerInvoiceSettingsInput {
+    custom_fields: [CreateStripeCustomerInvoiceSettingsCustomFieldsInput]
+    default_payment_method: String
+    footer: String
+    rendering_options: CreateStripeCustomerInvoiceSettingsRenderingOptionsInput
+}
+
+input CreateStripeCustomerInvoiceSettingsRenderingOptionsInput {
+    amount_tax_display: String
+}
+
+input CreateStripeCustomerInvoiceSettingsCustomFieldsInput {
+    name: String!
+    value: String!
+}
+
+input CreateStripeCustomerCashBalanceInput {
+    settings: CreateStripeCustomerCashBalanceSettingsInput
+}
+
+input CreateStripeCustomerCashBalanceSettingsInput {
+    reconciliation_mode: String
+}
+
+input CreateStripeCustomerShippingInput {
+    address: CreateStripeCustomerAddressInput!
+    name: String!
+    phone: String
+}
+
+input CreateStripeCustomerAddressInput {
+    city: String
+    country: String
+    line1: String
+    line2: String
+    postal_code: String
+    state: String
+}
+
 type Query {
     stripeCustomerSearch(query: String): StripeCustomer @skipAuth
+}
+
+type Mutation {
+    createStripeCustomer(data: CreateStripeCustomerInput): StripeCustomer @skipAuth
 }
 `

--- a/src/api/services/customers/customers.js
+++ b/src/api/services/customers/customers.js
@@ -13,3 +13,8 @@ export const stripeCustomerSearch = async ({ query }) => {
   })
   return latest[latest.length-1]
 }
+
+export const createStripeCustomer = async ({ data }) => {
+  const newCustomer = await stripe.customers.create(data)
+  return newCustomer
+}

--- a/src/api/services/index.js
+++ b/src/api/services/index.js
@@ -12,5 +12,5 @@ export const stripeServices = {
 }
 
 export { productByPrice } from './products/products'
-export { stripeCustomerSearch } from './customers/customers'
+export { stripeCustomerSearch, createStripeCustomer } from './customers/customers'
 export { createStripeCustomerPortalSession, configureStripeCustomerPortal } from './customerPortal/customerPortal'

--- a/src/web/hooks/index.js
+++ b/src/web/hooks/index.js
@@ -1,3 +1,4 @@
 export { useStripeCheckout } from './useStripeCheckout'
 export { useStripeCustomerPortal } from './useStripeCustomerPortal'
 export { useStripeCustomerSearch } from './useStripeCustomerSearch'
+export { useStripeCustomerCreate } from './useStripeCustomerCreate'

--- a/src/web/hooks/useStripeCheckout.js
+++ b/src/web/hooks/useStripeCheckout.js
@@ -1,8 +1,12 @@
 // import { loadStripe } from '@stripe/stripe-js'
+import { useContext } from 'react'
 import { useMutation } from '@redwoodjs/web'
+import { StripeContext } from '../provider/StripeContext'
 import gql from 'graphql-tag'
 
 export const useStripeCheckout = () => {
+  const context = useContext(StripeContext)
+
   // Create Session Mutation
   const [checkout] = useMutation(
     gql`
@@ -21,8 +25,9 @@ export const useStripeCheckout = () => {
     `
   )
  
-  return async ({ cart, successUrl, cancelUrl, customer, mode}) => {
-    const newCart = cart.map(item => ({ id: item.id, quantity: item.quantity }))
+  return async ({ cart, customer, successUrl, cancelUrl, mode }) => {
+    customer = customer || context.customer
+    const newCart = (cart || context.cart).map(item => ({ id: item.id, quantity: item.quantity }))
 
     // Determines checkout mode based on whether price "type" was passed to cart item or whther a "mode" was passed to checkout hook
     const determinedMode = (() => {
@@ -41,13 +46,13 @@ export const useStripeCheckout = () => {
         successUrl: successUrl,
         cancelUrl: cancelUrl,
         mode: determinedMode,
-        ... ((typeof customer !== "undefined" && customer !== null) && {
+        ... (customer != null ? {
           customer: {
             id: customer.id,
             name: customer.name,
             email: customer.email
-          }   
-        })
+          }
+        } : {})
       }
     }
 

--- a/src/web/hooks/useStripeCustomerCreate.js
+++ b/src/web/hooks/useStripeCustomerCreate.js
@@ -1,13 +1,12 @@
 import { useMutation } from '@redwoodjs/web'
 import gql from 'graphql-tag'
 
-export const useStripeCustomerCreate = () => {
+export const useStripeCustomerCreate = (returnValues) => {
     const [createStripeCustomer] = useMutation(
     gql`
       mutation createStripeCustomer($data: CreateStripeCustomerInput ) {
         createStripeCustomer(data: $data) {
-          id
-          email
+          ${returnValues}
         }
       }
     `

--- a/src/web/hooks/useStripeCustomerCreate.js
+++ b/src/web/hooks/useStripeCustomerCreate.js
@@ -1,0 +1,28 @@
+import { useMutation } from '@redwoodjs/web'
+import gql from 'graphql-tag'
+
+export const useStripeCustomerCreate = () => {
+    const [createStripeCustomer] = useMutation(
+    gql`
+      mutation createStripeCustomer($data: CreateStripeCustomerInput ) {
+        createStripeCustomer(data: $data) {
+          id
+          email
+        }
+      }
+    `
+    )
+    
+    return async (args) => {
+        // Create Payload
+        const payload = {
+            variables: {
+                data: args
+            }
+        }
+
+        // Create Customer Portal Session
+        const { data: { createStripeCustomer } } = await createStripeCustomer(payload)
+        return createStripeCustomer
+    }
+}

--- a/src/web/hooks/useStripeCustomerPortal.js
+++ b/src/web/hooks/useStripeCustomerPortal.js
@@ -1,7 +1,13 @@
+import { useContext } from 'react'
 import { useMutation } from '@redwoodjs/web'
+
+import { StripeContext } from '../provider/StripeContext'
+
 import gql from 'graphql-tag'
 
 export const useStripeCustomerPortal = () => {
+    const context = useContext(StripeContext)
+
     const [createStripeCustomerPortal] = useMutation(
     gql`
       mutation createStripeCustomerPorta($variables: StripeCustomerPortalInput ) {
@@ -16,9 +22,12 @@ export const useStripeCustomerPortal = () => {
     return async (args) => {
         // Create Payload
         const payload = {
+          variables: {
             variables: {
-                variables: args
+              ...(context.customer ? { customer: context.customer.id } : {}),
+              ...args
             }
+          }
         }
 
         // Create Customer Portal Session

--- a/src/web/hooks/useStripeCustomerSearch.js
+++ b/src/web/hooks/useStripeCustomerSearch.js
@@ -1,6 +1,8 @@
 import { useQuery } from '@redwoodjs/web'
 import gql from 'graphql-tag'
 
+import { isEmptyObj } from '../lib'
+
 export const useStripeCustomerSearch = (querystring) => {
   if (querystring === "") 
     return {
@@ -22,7 +24,7 @@ export const useStripeCustomerSearch = (querystring) => {
 
     const apolloResult = useQuery(
       STRIPE_CUSTOMER_SEARCH, {
-        skip: querystring === null,
+        skip: querystring === null || querystring === "",
         variables: {
           query: querystring  
         }

--- a/src/web/index.js
+++ b/src/web/index.js
@@ -1,5 +1,10 @@
 // export hooks
-export { useStripeCheckout, useStripeCustomerSearch, useStripeCustomerPortal } from './hooks'
+export {
+    useStripeCheckout,
+    useStripeCustomerSearch,
+    useStripeCustomerCreate,
+    useStripeCustomerPortal
+} from './hooks'
 
 // export components
 export * from './components'

--- a/src/web/lib/index.js
+++ b/src/web/lib/index.js
@@ -1,3 +1,9 @@
 export const logger = msg => {
     console.log('%c STRIPE: ','color: blue', msg)
 }
+
+export const isEmptyObj = obj => {
+return obj // 👈 null and undefined check
+&& Object.keys(obj).length === 0
+&& Object.getPrototypeOf(obj) === Object.prototype
+}

--- a/src/web/provider/StripeProvider/StripeProvider.js
+++ b/src/web/provider/StripeProvider/StripeProvider.js
@@ -4,15 +4,28 @@ import {
   useMemo,
 } from 'react'
 
-import { useStripeCustomerSearch } from '../../hooks'
+import { useStripeCustomerSearch, useStripeCustomerCreate } from '../../hooks'
 
 import { createStripeApi } from '../createStripeApi'
 import { StripeContext } from '../StripeContext'
 
-export const StripeProvider = ({ children, customerQS = "" }) => {
+export const StripeProvider = ({
+  children,
+  customer: {
+    search = "",
+    create = {}
+  } }) => {
   const [cart, setCart] = useState([])
-  const [customer, setCustomer] = useState({})
-  const { data, refetch } = useStripeCustomerSearch(customerQS)
+  const [user, setCustomer] = useState({})
+  const { data, refetch } = useStripeCustomerSearch(search)
+  const createStripeCustomer = useStripeCustomerCreate()
+
+  // const customerCheck = (returnedCustomer) => {
+  //   if (!returnedCustomer) {
+  //     const newCustomer = createStripeCustomer(create)
+
+  //   }
+  // }
   
   useEffect(() => {
     if (typeof data !== "undefined" && Object.hasOwn(data, "stripeCustomerSearch")) {
@@ -21,9 +34,9 @@ export const StripeProvider = ({ children, customerQS = "" }) => {
   }, [data])
 
   useEffect(() => {
-    const { stripeCustomerSearch } = refetch(customerQS)
+    const { stripeCustomerSearch } = refetch(search)
     setCustomer(stripeCustomerSearch)
-  }, [customerQS])
+  }, [search])
   
   // onMount fetch cart items from local storage
   // onMount fetch customer details from local storage
@@ -45,12 +58,12 @@ export const StripeProvider = ({ children, customerQS = "" }) => {
 
   useEffect(() => {
      setTimeout(() => {
-      window.localStorage.setItem('stripeCustomer', JSON.stringify(customer))
+      window.localStorage.setItem('stripeCustomer', JSON.stringify(user))
     })
-  }, [customer])
+  }, [user])
 
   // Only create new api obj when cart changes
-  const api = useMemo(() => createStripeApi(cart, setCart, customer), [cart])
+  const api = useMemo(() => createStripeApi(cart, setCart, user), [cart])
   return (
     <StripeContext.Provider value={api}>
       {children}

--- a/src/web/provider/StripeProvider/StripeProvider.js
+++ b/src/web/provider/StripeProvider/StripeProvider.js
@@ -4,7 +4,7 @@ import {
   useMemo,
 } from 'react'
 
-import { useStripeCustomerSearch, useStripeCustomerCreate } from '../../hooks'
+import { useStripeCustomerSearch } from '../../hooks'
 
 import { createStripeApi } from '../createStripeApi'
 import { StripeContext } from '../StripeContext'
@@ -12,20 +12,11 @@ import { StripeContext } from '../StripeContext'
 export const StripeProvider = ({
   children,
   customer: {
-    search = "",
-    create = {}
+    search = ""
   } }) => {
   const [cart, setCart] = useState([])
-  const [user, setCustomer] = useState({})
+  const [stripeCustomer, setCustomer] = useState({})
   const { data, refetch } = useStripeCustomerSearch(search)
-  // const createStripeCustomer = useStripeCustomerCreate()
-
-  // const customerCheck = (returnedCustomer) => {
-  //   if (!returnedCustomer) {
-  //     const newCustomer = createStripeCustomer(create)
-
-  //   }
-  // }
   
   useEffect(() => {
     if (typeof data !== "undefined" && Object.hasOwn(data, "stripeCustomerSearch")) {
@@ -58,12 +49,12 @@ export const StripeProvider = ({
 
   useEffect(() => {
      setTimeout(() => {
-      window.localStorage.setItem('stripeCustomer', JSON.stringify(user))
+      window.localStorage.setItem('stripeCustomer', JSON.stringify(stripeCustomer))
     })
-  }, [user])
+  }, [stripeCustomer])
 
   // Only create new api obj when cart changes
-  const api = useMemo(() => createStripeApi(cart, setCart, user), [cart])
+  const api = useMemo(() => createStripeApi(cart, setCart, stripeCustomer), [cart])
   return (
     <StripeContext.Provider value={api}>
       {children}

--- a/src/web/provider/StripeProvider/StripeProvider.js
+++ b/src/web/provider/StripeProvider/StripeProvider.js
@@ -18,7 +18,7 @@ export const StripeProvider = ({
   const [cart, setCart] = useState([])
   const [user, setCustomer] = useState({})
   const { data, refetch } = useStripeCustomerSearch(search)
-  const createStripeCustomer = useStripeCustomerCreate()
+  // const createStripeCustomer = useStripeCustomerCreate()
 
   // const customerCheck = (returnedCustomer) => {
   //   if (!returnedCustomer) {

--- a/templates/web/src/pages/StripeDemoPage/StripeDemoPage.js
+++ b/templates/web/src/pages/StripeDemoPage/StripeDemoPage.js
@@ -23,12 +23,18 @@ const StripeDemoPage = () => {
     setCartVisibilty(!isCartVisible)
   }
 
+  // This is a stub, please implement
   const userEmailFromAuth = 'loggedinuser@domain.com'
+  const IsLoggedIn = true
 
   return (
     <>
-      {/* customerQS uses a query string to search for a customer on Stripe */}
-      <StripeProvider customerQS={`email: "${userEmailFromAuth}"`}>
+      {/* search uses a query string to search for a customer on Stripe */}
+      <StripeProvider
+        customer={{
+          search: IsLoggedIn ? `email: "${userEmailFromAuth}"` : '',
+        }}
+      >
         <MetaTags
           title="Stripe Demo"
           description="A demo page for the redwoodjs-stripe integration"
@@ -79,18 +85,19 @@ const StripeDemoPage = () => {
 export default StripeDemoPage
 
 const StripeCustomerPortalButton = () => {
-  const { customer } = useStripeCart()
+  // This is a stub, please implement
+  const isLoggedIn = true
+
   const redirectToStripeCustomerPortal = useStripeCustomerPortal()
 
   const onButtonClick = async () => {
     await redirectToStripeCustomerPortal({
-      customer: customer.id,
       return_url: 'http://localhost:8910/stripe-demo',
     })
   }
 
   return (
-    customer && (
+    isLoggedIn && (
       <button className="rws-button" onClick={onButtonClick}>
         <Icon name="user" />
       </button>
@@ -119,11 +126,10 @@ const CartCounter = () => {
 
 const StripeCart = () => {
   const checkout = useStripeCheckout()
-  const { cart, customer, clearCart } = useStripeCart()
+  const { cart, clearCart } = useStripeCart()
 
   const onCheckoutButtonClick = async () => {
     await checkout({
-      customer: customer,
       cart: cart,
       successUrl:
         'http://localhost:8910/stripe-demo?success=true&sessionId={CHECKOUT_SESSION_ID}',


### PR DESCRIPTION
Added some create Stripe Customer functionality but not tested. Will continue work on it if need arises. Instead abstracted out "cart" and "customer" from `useStripeCheckout` and `useStripeCustomerPortal`

**before**
```
 const { customer } = useStripeCart()
  const redirectToStripeCustomerPortal = useStripeCustomerPortal()

  const onButtonClick = async () => {
    await redirectToStripeCustomerPortal({
      customer: customer.id,
      return_url: 'http://localhost:8910/stripe-demo',
    })
  }
```

**now**
```
 const redirectToStripeCustomerPortal = useStripeCustomerPortal()

  const onButtonClick = async () => {
    await redirectToStripeCustomerPortal({
      return_url: 'http://localhost:8910/stripe-demo',
    })
  }
```
