### PR TITLE
fix: remove `@redwoodjs/*` packages from `peerDependencies` to reduce bundle size

### DIFF
--- a/package.json
+++ b/package.json
@@ -75,8 +75,6 @@
   },
   "peerDependencies": {
     "@apollo/client": "3.x",
-    "@redwoodjs/core": "4.x",
-    "@redwoodjs/web": "4.x",
     "graphql-tag": "2.x",
     "react": "17.0.2",
     "react-dom": "17.0.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -5333,8 +5333,6 @@ __metadata:
     yargs: ^17.5.1
   peerDependencies:
     "@apollo/client": 3.x
-    "@redwoodjs/core": 4.x
-    "@redwoodjs/web": 4.x
     graphql-tag: 2.x
     react: 17.0.2
     react-dom: 17.0.2


### PR DESCRIPTION
Before https://github.com/chrisvdm/redwoodjs-stripe/pull/83, let's try this. The intention in listing `@redwoodjs/core` and `/web` in `peerDependencies` is right, but it seems like [Netlify's zisi (zip-it-and-ship-it) bundler](https://github.com/netlify/zip-it-and-ship-it) is interpreting this line as "I guess I should include all of `@redwoodjs/core` in the lambda", which definitely isn't what we want since it's mostly devDependencies. We can figure out version compatibility another way. Locally this reduced the bundle size from 200MB+ to ~27MB.

@chrisvdm as the next step, do you think we could merge this, release a new RC, and see if we can deploy?