### PR TITLE
fix(StripeProvider): clean up setTimeout in useEffect

### DIFF
--- a/web/src/provider/StripeProvider/StripeProvider.js
+++ b/web/src/provider/StripeProvider/StripeProvider.js
@@ -50,9 +50,13 @@ export const StripeProvider = ({
 
   // sync Cart with localStorage
   useEffect(() => {
-    setTimeout(() => {
+    const timeoutId = setTimeout(() => {
       window.localStorage.setItem('stripeCart', JSON.stringify(cart))
     })
+
+    return () => {
+      clearTimeout(timeoutId)
+    }
   }, [cart])
 
   // Only create new api obj when cart and stripeCustomer changes


### PR DESCRIPTION
We should clean up the `setTimeout` here. Here's a small example in the React docs: https://react.dev/learn/synchronizing-with-effects#putting-it-all-together