### PR TITLE
improv(cli): change key prompts to password

### DIFF
--- a/cli/src/setup.js
+++ b/cli/src/setup.js
@@ -11,17 +11,17 @@ const prompt = (initialOptions) =>
   prompts(
     [
       {
-        type: 'text',
+        type: 'password',
         name: 'stripeSecretKey',
         message: 'What is your Stripe secret key?',
       },
       {
-        type: 'text',
+        type: 'password',
         name: 'stripePublishableKey',
         message: 'What is your Stripe publishable key?',
       },
       {
-        type: 'text',
+        type: 'password',
         name: 'stripeWebhookKey',
         message:
           "What is your Stripe Webhook Endpoint key (it's okay if you dont have one right now)?",


### PR DESCRIPTION
Since we're pasting keys in the terminal, it feels better to do it if the fields are password instead of plain text.

Without these changes:
<img width="591" alt="image" src="https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/c7e89d9b-988d-46d7-8e48-c9b2a07335a7">

With these changes:
<img width="591" alt="image" src="https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/068eb25f-d51d-406e-b042-588a4fa42dbf">
