### PR TITLE
improv: use modern yargs

### DIFF
--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -1,25 +1,29 @@
 #!/usr/bin/env node
-const yargs = require("yargs");
+const yargs = require("yargs/yargs");
+const { hideBin } = require('yargs/helpers')
 
 const { setup } = require("./setup");
 const { upgrade } = require("./upgrade");
 
-const main = () =>
-  yargs.scriptName("redwoodjs-stripe").command({
-    command: "setup",
-    describe: "Scaffolds out the files needed for using stripe with redwood",
-    handler(args) {
-      setup(args);
-    },
-  })
-  .command({
-    command: "upgrade",
-    describe: "Upgrades plugin's api and web side packages",
-    handler(args) {
-      upgrade(args);
-    },
-  })
-  .argv;
+const main = () => {
+  yargs(hideBin(process.argv))
+    .scriptName("redwoodjs-stripe")
+    .command({
+      command: "setup",
+      describe: "Scaffolds out the files needed for using Stripe with Redwood",
+      async handler(args) {
+        await setup(args);
+      },
+    })
+    .command({
+      command: "upgrade",
+      describe: "Upgrades the plugin's api and web side packages",
+      async handler(args) {
+        await upgrade(args);
+      },
+    })
+    .parse();
+}
 
 if (require.main === module) {
   main();

--- a/cli/src/cli.js
+++ b/cli/src/cli.js
@@ -8,6 +8,7 @@ const { upgrade } = require("./upgrade");
 const main = () => {
   yargs(hideBin(process.argv))
     .scriptName("redwoodjs-stripe")
+    .demandCommand()
     .command({
       command: "setup",
       describe: "Scaffolds out the files needed for using Stripe with Redwood",


### PR DESCRIPTION
Yargs recommends using
- `yargs` from `yargs/yargs`
- `hideBin` from `yargs/helpers`
- `parse` instead of `argv`

See the example here: https://github.com/yargs/yargs#complex-example

---

When the CLI is run without any commands, nothing happens:


https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/a14b4619-4ea9-4475-a8bc-3d91808286c7

Using `demmandCommand` we can report an error:

https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/e1382f0a-3cb3-457b-8a6c-2cb22007ab75
