### PR TITLE
fix: don't generate demo page twice

### DIFF
--- a/cli/src/setup.js
+++ b/cli/src/setup.js
@@ -100,11 +100,6 @@ const scaffold = async (options) => {
   }
 
   await updateDotEnv(options);
-
-  if (!shouldSkip(options, 'rwGenerate')) {
-    await exec('yarn rw g page stripe-demo', { cwd: options.dir });
-  }
-
   await copyTemplateFiles(options);
 };
 


### PR DESCRIPTION
@chrisvdm I'm not sure if we need to generate the StripeDemo page anymore? When I first ran `npx @redwoodjs-stripe/cli@latest setup`, I got this error on `yarn rw dev`:

![image](https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/a625abbc-4b3a-4f5f-a4d3-17f0ab486458)

I discovered that there's two pages in `web/src/pages/StripeDemoPage`. It seems like one is coming from `yarn rw g page StripeDemo` and the other is coming from copying the templates:

<img width="301" alt="image" src="https://github.com/chrisvdm/redwoodjs-stripe/assets/32992335/11c7603d-9623-4e9a-81f0-0312174f0d1d">

This error may only appear in TS projects where the generate command generates a `.tsx` file while copying the template copies over a `.js` file.