### PR TITLE
improv: don't read dotenv

### DIFF
--- a/cli/src/setup.js
+++ b/cli/src/setup.js
@@ -40,20 +40,11 @@ const prompt = (initialOptions) =>
 const updateDotEnv = async (options) => {
   const dotEnvPath = path.join(options.dir, '.env');
 
-  const rawEnv = (await fs.pathExists(dotEnvPath))
-    ? await fs.readFile(dotEnvPath)
-    : '';
-
-  const currentEnv = envfile.parse(rawEnv);
-
-  const nextEnv = {
-    ...currentEnv,
-    STRIPE_SECRET_KEY: options.stripeSecretKey,
-    STRIPE_PUBLISHABLE_KEY: options.stripePublishableKey,
-    STRIPE_WEBHOOK_KEY: options.stripeWebhookKey,
-  };
-
-  await fs.writeFile(dotEnvPath, envfile.stringify(nextEnv));
+  fs.appendFileSync(dotEnvPath, [
+    `STRIPE_SECRET_KEY='${options.stripeSecretKey}'`,
+    `STRIPE_PUBLISHABLE_KEY='${options.stripePublishableKey}'`,
+    `STRIPE_WEBHOOK_KEY='${options.stripeWebhookKey}'`,
+  ].join('\n'))
 };
 
 const addDummyProducts = async (options) => {


### PR DESCRIPTION
I'm not sure if this a huge deal or not, we obviously don't do anything with it, but lets not read a user's dotenv if we don't have to, let's just append to it. `fs.appendFileSync` should make the file if it doesn't exist