### PR TITLE
improv: use `@ts-check` in the CLI's setup command

### DIFF
--- a/cli/src/setup.js
+++ b/cli/src/setup.js
@@ -1,3 +1,5 @@
+// @ts-check
+
 const Tasks = require('listr');
 const prompts = require('prompts');
 const fs = require('fs-extra');
@@ -34,7 +36,7 @@ const prompt = (initialOptions) =>
           'Would you like us to add dummy products to your Stripe account?',
         initial: false,
       },
-    ].filter((item) => initialOptions[item.name] == null)
+    ]
   );
 
 const updateDotEnv = async (options) => {
@@ -86,9 +88,7 @@ const copyTemplateFiles = async (options) => {
 
   await fs.mkdirp(srcDir);
 
-  await fs.copy(srcDir, destDir, {
-    recursive: true,
-  });
+  await fs.copy(srcDir, destDir);
 };
 
 const shouldSkip = (options, step) => [...(options.skip || [])].includes(step);


### PR DESCRIPTION
Migrating everything to TS may be too much, but It's probably worth at least using the `@ts-check` directive. Enabling it here indicated two things: 1) maybe we could simplify the array we're passing to prompts (I'm not sure what the filter for name == null was for exactly?) 2) `fs.copy` doesn't take a `recursive` option: https://github.com/jprichardson/node-fs-extra/blob/cc7b3b22a984de5124131c7897574091c9df00e1/docs/copy.md