### PR TITLE
Bug/stripe webhook test fail

### DIFF
--- a/api/src/index.js
+++ b/api/src/index.js
@@ -1,5 +1,6 @@
 export {
     handleStripeWebhooks,
+    generateStripeMockEvent,
     stripe
 } from './lib'
 

--- a/cli/templates/api/src/functions/stripeWebhook/stripeWebhook.test.js
+++ b/cli/templates/api/src/functions/stripeWebhook/stripeWebhook.test.js
@@ -1,41 +1,13 @@
-import { mockHttpEvent } from '@redwoodjs/testing/api'
-
-import { stripe } from 'src/lib/stripe'
-
-import { handler } from './stripeWebhook'
+import {
+  handleStripeWebhooks,
+  generateStripeMockEvent,
+} from '@redwoodjs-stripe/api'
 
 describe('stripeWebhooks function', () => {
   it('Should respond with 200', async () => {
-    /**
-     * Copied from Stripe's tests: {@link https://github.com/stripe/stripe-node/blob/master/test/Webhook.spec.js#L8-L12}
-     */
-    const payload = JSON.stringify(
-      {
-        id: 'evt_test_webhook',
-        object: 'event',
-      },
-      null,
-      2
-    )
+    const mockStripeEvent = generateStripeMockEvent()
 
-    process.env.STRIPE_WEBHOOK_SK = 'whsec_test_secret'
-
-    /**
-     * @see {@link https://github.com/stripe/stripe-node/blob/master/README.md#testing-webhook-signing}
-     */
-    const header = stripe.webhooks.generateTestHeaderString({
-      payload,
-      secret: process.env.STRIPE_WEBHOOK_SK,
-    })
-
-    const httpEvent = mockHttpEvent({
-      body: payload,
-      headers: {
-        'stripe-signature': header,
-      },
-    })
-
-    const response = await handler(httpEvent, null)
+    const response = await handleStripeWebhooks(mockStripeEvent, {}, {}, false)
 
     expect(response.statusCode).toBe(200)
   })


### PR DESCRIPTION
- Create a function to create test events for Stripe Webhooks
```js
import {  generateStripeMockEvent } from @redwoodjs-stripe/api
```
- update cli template to use new webhook test

closes #108 