### PR TITLE
fix: remove extension from require('superpowers.json')

### DIFF
--- a/cli/src/setup.js
+++ b/cli/src/setup.js
@@ -69,7 +69,7 @@ const addDummyProducts = async (options) => {
 
   // esbuild parses JSON files into JS objects at build time.
   // See https://esbuild.github.io/content-types/#json.
-  const superpowers = require('./superpowers.json');
+  const superpowers = require('./superpowers');
 
   for (const superpower of superpowers) {
     const { prices, ...productData } = superpower;

--- a/yarn.lock
+++ b/yarn.lock
@@ -7709,11 +7709,11 @@ __metadata:
 
 "typescript@patch:typescript@>=3 < 6#~builtin<compat/typescript>":
   version: 5.1.3
-  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=1f5320"
+  resolution: "typescript@patch:typescript@npm%3A5.1.3#~builtin<compat/typescript>::version=5.1.3&hash=5da071"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 32a25b2e128a4616f999d4ee502aabb1525d5647bc8955e6edf05d7fbc53af8aa98252e2f6ba80bcedfc0260c982b885f3c09cfac8bb65d2924f3133ad1e1e62
+  checksum: 6f0a9dca6bf4ce9dcaf4e282aade55ef4c56ecb5fb98d0a4a5c0113398815aea66d871b5611e83353e5953a19ed9ef103cf5a76ac0f276d550d1e7cd5344f61e
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Fixes a bug introduced in https://github.com/chrisvdm/redwoodjs-stripe/pull/112. If we specify the extension, we'll end up with an error at runtime since esbuild transforms `superpower.json` into `superpower.js`. Node will be able to resolve the file if we remove the extension.