### PR TITLE
Improv/sdl generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
     "build": "yarn tasks --task build",
     "release": "yarn build && lerna publish from-package",
     "sync": "yarn tasks --task sync --target",
-    "tasks": "./scripts/tasks.js"
+    "tasks": "./scripts/tasks.js",
+    "gs": "node ./schema/scripts/index.js"
   },
   "dependencies": {
     "chokidar": "^3.5.3",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
   "workspaces": [
     "api",
     "web",
-    "cli"
+    "cli",
+    "schema"
   ],
   "scripts": {
     "build": "yarn tasks --task build",

--- a/schema/package.json
+++ b/schema/package.json
@@ -16,6 +16,8 @@
   ],
   "dependencies": {
     "@envelop/core": "^4.0.0",
+    "@envelop/parser-cache": "^6.0.1",
+    "@envelop/validation-cache": "^6.0.1",
     "graphql": "^16.7.1"
   }
 }

--- a/schema/package.json
+++ b/schema/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "@redwoodjs-stripe/schema",
+  "version": "0.0.0",
+  "description": "Yoga GraphQL plugin that builds sdl from Stripe's OpenAPI",
+  "keywords": [
+    "stripe",
+    "redwoodjs",
+    "yoga-graphql",
+    "schema"
+  ],
+  "license": "MIT",
+  "author": "chrisvdm",
+  "main": "./dist/index.js",
+  "files": [
+    "dist"
+  ]
+}

--- a/schema/package.json
+++ b/schema/package.json
@@ -15,6 +15,7 @@
     "dist"
   ],
   "dependencies": {
+    "@envelop/core": "^4.0.0",
     "graphql": "^16.7.1"
   }
 }

--- a/schema/package.json
+++ b/schema/package.json
@@ -13,5 +13,8 @@
   "main": "./dist/index.js",
   "files": [
     "dist"
-  ]
+  ],
+  "dependencies": {
+    "graphql": "^16.7.1"
+  }
 }

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -14,9 +14,9 @@ const main = async () => {
         const activeObjects = ["checkout.session", "subscription"]
 
         // Create new array of openapi schema objects
-        let activeObjectsOpenAPI = []
+        let activeObjectsOpenAPI = {}
         activeObjects.forEach(obj => {
-            activeObjectsOpenAPI.push(openAPISchema[obj])
+            activeObjectsOpenAPI[obj] = openAPISchema[obj]
         });
         console.log(activeObjectsOpenAPI)
 

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -15,10 +15,10 @@ const main = async () => {
       const activeTypes = ["checkout.session", "customer"]
       console.log(Object.keys(openAPISchema))
 
-      // Constructing types from Query
+      // Constructing types from Query (excluding resolvers for first iteration)
       // https://graphql.org/graphql-js/constructing-types/
 
-      // Reference for development
+      // Reference for development:
       // `type Query {
       //   stripeCustomer(id: $id): StripeCustomer
       //   stripeCheckoutSession(id: $id): StripeCheckoutSession
@@ -28,13 +28,31 @@ const main = async () => {
       //    1st iteration:  Build from scratch
       //    2nd iteraction: Build from sdl
 
+      // Define the Query type
+      const queryType = new graphql.GraphQLObjectType({
+        name: "Query",
+        fields: {
+          stripeCustomer: {
+            type: getGraphQLObjectType('stripeCustomer'),
+            args: {
+              id: { type: graphql.GraphQLID },
+            }
+          },
+        },
+      })
+
+      const getGraphQLObjectType = (name) => {
+
+      }
+
       // 2. Build out types defined in QueryType
       //      1st iteration: Build first level properties
       //      2nd iteration: Build recursively as required for QueryType
 
-      // 3. PrintSchema
-      
+      // 3. Create new schema using Query as the root  
+      // var schema = new graphql.GraphQLSchema({ query: queryType })
 
+      // console.log(schema)
 
 
 

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -101,10 +101,11 @@ const main = async () => {
         const isRef = Object.hasOwn(properties, `\$ref`)
         const isUnion = Object.hasOwn(properties, 'anyOf')
         const isEnum = Object.hasOwn(properties, 'enum')
+        const isArray = properties.type === 'array'
         const isHash = properties.type === 'object' && !Object.hasOwn(properties, 'properties') && !isExpandable
         const isObject = !isHash && properties.type === 'object'
 
-        if (!isRef && !isUnion && !isHash && !isObject && !isEnum) {
+        if (!isRef && !isUnion && !isHash && !isObject && !isEnum && !isArray) {
             return getGraphQLBasicType(properties.type)
         }
         

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -1,0 +1,5 @@
+const main = () => {
+    console.log("bruh")
+}
+
+main()

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -53,6 +53,12 @@ const main = async () => {
         return words[0]
       } // end toCamelCase fn
 
+      const getHashGraphQLType = () => {
+        return new graphql.GraphQLScalarType({
+          name: "Hash"
+        })
+      }
+
       const getEnumGraphQLType = (ugh) => {
         const { name, title, props } = ugh
 
@@ -100,13 +106,13 @@ const main = async () => {
           return getEnumGraphQLType(schema)
         }
         if (isHash) {
+          return getHashGraphQLType()
+        }
+        if (isUnion) {
           return
         }
         if (isRef) {
           return 
-        }
-        if (isUnion) {
-          return
         }
         if (isObject) {
           return
@@ -127,7 +133,7 @@ const main = async () => {
         // Goes through each property and return corresponding GraphQL Types
         Object.keys(properties).forEach(name => {
           const props = properties[name]
-          const isRequired = required.includes(name)
+          // const isRequired = required.includes(name)
 
           const propGraphQLType = getPropertyGraphQLType({
             name: name,

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -1,5 +1,5 @@
 const fetch = require('node-fetch');
-const { buildSchema } = require("graphql")
+const graphql = require("graphql")
 
 const main = async () => {
     try {
@@ -29,21 +29,79 @@ const main = async () => {
       //    2nd iteraction: Build from sdl
 
       // Define the Query type
-      const queryType = new graphql.GraphQLObjectType({
-        name: "Query",
-        fields: {
-          stripeCustomer: {
-            type: getGraphQLObjectType('stripeCustomer'),
-            args: {
-              id: { type: graphql.GraphQLID },
-            }
-          },
-        },
-      })
+      // const queryType = new graphql.GraphQLObjectType({
+      //   name: "Query",
+      //   fields: {
+      //     stripeCustomer: {
+      //       type: getGraphQLObjectType('customer', context),
+      //       args: {
+      //         id: { type: graphql.GraphQLID },
+      //       }
+      //     },
+      //   },
+      // })
+
+      const getGraphQLType = ({ type, isRequired}) => {
+        switch (type) {
+          case 'string':
+            return graphql.GraphQLString
+          case 'integer':
+            return graphql.GraphQLInt
+          case 'boolean':
+            return graphql.GraphQLBoolean
+          case 'id':
+            return graphql.GraphQLID
+        }
+      }
 
       const getGraphQLObjectType = (name) => {
+        let objectFieldsGraphQLType = {}
+        // TODO sanitise name string
+        // - remove 'stripe' prefix
 
+        // get data from openAPISchema
+        const ugh = openAPISchema[name]
+        const { properties, required, title } = ugh
+        const expandable = ugh['x-expandableFields']
+        
+        // Goes through each property and return corresponding GraphQL Types
+        Object.keys(properties).forEach(name => {
+          const prop = properties[name]
+          let propGraphQLType = ''
+
+          // determine whether prop is scalar
+          const isRef = Object.hasOwn(prop, `\$ref`)
+          const isUnion = Object.hasOwn(prop, 'AnyOf')
+          const isEnum = Object.hasOwn(prop, 'enum')
+          const isHash = prop.type === 'object' && !Object.hasOwn(prop, 'properties') && !expandable.includes(name)
+          const isObject = !isHash && prop.type === 'object'
+          
+          const isRequired = !required.includes(name)
+
+          const propValues = {
+            objectName: name,
+            ...prop,
+            isRequired,
+          }
+
+          if (!isRef && !isUnion && !isHash && !isObject && !isEnum ) {
+             propGraphQLType = getGraphQLType(propValues)
+          }
+
+          objectFieldsGraphQLType[name]= {
+            type: propGraphQLType
+          }
+
+        });
+
+        // Construct object type
+        return new graphql.GraphQLObjectType({
+          name: `stripe${title}`,
+          fields: {...objectFieldsGraphQLType},
+        })
       }
+
+      console.log(getGraphQLObjectType('checkout.session'))
 
       // 2. Build out types defined in QueryType
       //      1st iteration: Build first level properties
@@ -53,8 +111,6 @@ const main = async () => {
       // var schema = new graphql.GraphQLSchema({ query: queryType })
 
       // console.log(schema)
-
-
 
   } catch (err) {
     console.log('fetch error', err);

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -1,5 +1,28 @@
-const main = () => {
-    console.log("bruh")
+const fetch = require('node-fetch');
+
+const main = async () => {
+    try {
+        // Fetch Stripe openAPI spec
+        const openAPIBlob = await fetch('https://raw.githubusercontent.com/stripe/openapi/master/openapi/spec3.json');
+        const openAPI = JSON.parse(await openAPIBlob.text());
+
+        // Retrieve schema information
+        const openAPISchema = openAPI.components.schemas
+
+        // Specify active (used) Stripe Objects
+        // TODO: Empty array leads to all objects being processed
+        const activeObjects = ["checkout.session", "subscription"]
+
+        // Create new array of openapi schema objects
+        let activeObjectsOpenAPI = []
+        activeObjects.forEach(obj => {
+            activeObjectsOpenAPI.push(openAPISchema[obj])
+        });
+        console.log(activeObjectsOpenAPI)
+
+  } catch (err) {
+    console.log('fetch error', err);
+  }
 }
 
 main()

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -12,43 +12,30 @@ const main = async () => {
 
         // Specify active (used) Stripe Objects
         // TODO: Empty array leads to all objects being processed
-      const activeObjects = ["checkout.session", "customer"]
-      
-      const schemaQueryRootType = buildSchema(`
-        type Query {
-          _: String!
-        }
-      `)
+      const activeTypes = ["checkout.session", "customer"]
+      console.log(Object.keys(openAPISchema))
 
-      const queryType = new GraphQLObjectType({
-    name: 'Query',
-    fields: () => {
-      const result = {};
-      for (const [name, type] of context.types.entries()) {
-        // It's ok to ignore the object injection attack here because
-        // the object being edited does not contain any private data to be
-        // protected and none of the attributes will be used as functions
-        // just a map of attribute to values.
-        // eslint-disable-next-line security/detect-object-injection
-        result[name] = { type };
-      }
-      return result;
-    }
-  });
-        console.log(queryType)
-        // Create new object of openapi schema objects
-        // let graphqlTypes = {}
-        // activeObjects.forEach(obj => {
-        //   const jsonType = openAPISchema[obj]
+      // Constructing types from Query
+      // https://graphql.org/graphql-js/constructing-types/
 
-        //   graphqlTypes[graphqlTypeNameFromJsonTypeName(obj)] = buildGraphQLType(jsonType)
-        // });
+      // Reference for development
+      // `type Query {
+      //   stripeCustomer(id: $id): StripeCustomer
+      //   stripeCheckoutSession(id: $id): StripeCheckoutSession
+      // }`
+
+      // 1. Build Query GraphQL Types
+      //    1st iteration:  Build from scratch
+      //    2nd iteraction: Build from sdl
+
+      // 2. Build out types defined in QueryType
+      //      1st iteration: Build first level properties
+      //      2nd iteration: Build recursively as required for QueryType
+
+      // 3. PrintSchema
       
-        // const buildGraphQLType = (jsonType) => new GraphQLObjectType({
-        //   fields: jsonType.properties.map(graphQLObjectFieldFromJsonTypeProperty)
-        // })
-      
-        // const graphqlTypes = {}
+
+
 
 
   } catch (err) {
@@ -57,19 +44,3 @@ const main = async () => {
 }
 
 main()
-
-// const types = {}
-// types.checkoutSession = new GraphQLObjectType({
-//   fields: checkoutSessionProperties.map(prop => ({
-//     type: types.customer
-//   }))
-// })
-
-// const queryType = new GraphQLObjectType({
-//     name: 'Query',
-//     fields: {
-//       checkoutSession: {
-//         type: types.checkoutSession, 
-//       }
-//     }
-//   });

--- a/schema/scripts/index.js
+++ b/schema/scripts/index.js
@@ -1,4 +1,5 @@
 const fetch = require('node-fetch');
+const { buildSchema } = require("graphql")
 
 const main = async () => {
     try {
@@ -11,14 +12,44 @@ const main = async () => {
 
         // Specify active (used) Stripe Objects
         // TODO: Empty array leads to all objects being processed
-        const activeObjects = ["checkout.session", "subscription"]
+      const activeObjects = ["checkout.session", "customer"]
+      
+      const schemaQueryRootType = buildSchema(`
+        type Query {
+          _: String!
+        }
+      `)
 
-        // Create new array of openapi schema objects
-        let activeObjectsOpenAPI = {}
-        activeObjects.forEach(obj => {
-            activeObjectsOpenAPI[obj] = openAPISchema[obj]
-        });
-        console.log(activeObjectsOpenAPI)
+      const queryType = new GraphQLObjectType({
+    name: 'Query',
+    fields: () => {
+      const result = {};
+      for (const [name, type] of context.types.entries()) {
+        // It's ok to ignore the object injection attack here because
+        // the object being edited does not contain any private data to be
+        // protected and none of the attributes will be used as functions
+        // just a map of attribute to values.
+        // eslint-disable-next-line security/detect-object-injection
+        result[name] = { type };
+      }
+      return result;
+    }
+  });
+        console.log(queryType)
+        // Create new object of openapi schema objects
+        // let graphqlTypes = {}
+        // activeObjects.forEach(obj => {
+        //   const jsonType = openAPISchema[obj]
+
+        //   graphqlTypes[graphqlTypeNameFromJsonTypeName(obj)] = buildGraphQLType(jsonType)
+        // });
+      
+        // const buildGraphQLType = (jsonType) => new GraphQLObjectType({
+        //   fields: jsonType.properties.map(graphQLObjectFieldFromJsonTypeProperty)
+        // })
+      
+        // const graphqlTypes = {}
+
 
   } catch (err) {
     console.log('fetch error', err);
@@ -26,3 +57,19 @@ const main = async () => {
 }
 
 main()
+
+// const types = {}
+// types.checkoutSession = new GraphQLObjectType({
+//   fields: checkoutSessionProperties.map(prop => ({
+//     type: types.customer
+//   }))
+// })
+
+// const queryType = new GraphQLObjectType({
+//     name: 'Query',
+//     fields: {
+//       checkoutSession: {
+//         type: types.checkoutSession, 
+//       }
+//     }
+//   });

--- a/schema/src/index.js
+++ b/schema/src/index.js
@@ -1,0 +1,5 @@
+const main = () => {
+    console.log("bruh")
+}
+
+main()

--- a/schema/src/index.js
+++ b/schema/src/index.js
@@ -1,5 +1,2 @@
-const main = () => {
-    console.log("bruh")
-}
-
-main()
+import * as GraphQLJS from 'graphql'
+import { envelop, useEngine, useSchema } from '@envelop/core'

--- a/scripts/tasks.js
+++ b/scripts/tasks.js
@@ -25,6 +25,10 @@ const configs = {
     cli: {
         platform: 'node',
         format: 'cjs',
+    },
+    schema: {
+        platform: 'node',
+        format: 'cjs',
     }
 }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1327,6 +1327,8 @@ __metadata:
 "@redwoodjs-stripe/schema@workspace:schema":
   version: 0.0.0-use.local
   resolution: "@redwoodjs-stripe/schema@workspace:schema"
+  dependencies:
+    graphql: ^16.7.1
   languageName: unknown
   linkType: soft
 
@@ -3497,6 +3499,13 @@ __metadata:
   version: 4.2.11
   resolution: "graceful-fs@npm:4.2.11"
   checksum: ac85f94da92d8eb6b7f5a8b20ce65e43d66761c55ce85ac96df6865308390da45a8d3f0296dd3a663de65d30ba497bd46c696cc1e248c72b13d6d567138a4fc7
+  languageName: node
+  linkType: hard
+
+"graphql@npm:^16.7.1":
+  version: 16.7.1
+  resolution: "graphql@npm:16.7.1"
+  checksum: c924d8428daf0e96a5ea43e9bc3cd1b6802899907d284478ac8f705c8fd233a0a51eef915f7569fb5de8acb2e85b802ccc6c85c2b157ad805c1e9adba5a299bd
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1324,6 +1324,12 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@redwoodjs-stripe/schema@workspace:schema":
+  version: 0.0.0-use.local
+  resolution: "@redwoodjs-stripe/schema@workspace:schema"
+  languageName: unknown
+  linkType: soft
+
 "@redwoodjs-stripe/web@workspace:web":
   version: 0.0.0-use.local
   resolution: "@redwoodjs-stripe/web@workspace:web"

--- a/yarn.lock
+++ b/yarn.lock
@@ -410,6 +410,25 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@envelop/core@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "@envelop/core@npm:4.0.0"
+  dependencies:
+    "@envelop/types": 4.0.0
+    tslib: ^2.5.0
+  checksum: 575039dfebeadaac3ea61fd700dcc806e26f04f045dc4457052b7cc1ca7c9c37bf9a98a8e4d377d20c69a4e7dc62c11b8884b70f2a218944736ee58c588d498b
+  languageName: node
+  linkType: hard
+
+"@envelop/types@npm:4.0.0":
+  version: 4.0.0
+  resolution: "@envelop/types@npm:4.0.0"
+  dependencies:
+    tslib: ^2.5.0
+  checksum: cd8bad3ef7d9ee6015e3befbd27a1fb66a560d1397111b0fe22d8a107c7509ab48f183752d514321e35e9c27e9e970e004579867d64105768fce69ccca411ac7
+  languageName: node
+  linkType: hard
+
 "@esbuild/android-arm64@npm:0.18.11":
   version: 0.18.11
   resolution: "@esbuild/android-arm64@npm:0.18.11"
@@ -1328,6 +1347,7 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@redwoodjs-stripe/schema@workspace:schema"
   dependencies:
+    "@envelop/core": ^4.0.0
     graphql: ^16.7.1
   languageName: unknown
   linkType: soft
@@ -7197,6 +7217,13 @@ __metadata:
   version: 2.5.3
   resolution: "tslib@npm:2.5.3"
   checksum: 88902b309afaf83259131c1e13da1dceb0ad1682a213143a1346a649143924d78cf3760c448b84d796938fd76127183894f8d85cbb3bf9c4fddbfcc140c0003c
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.5.0":
+  version: 2.6.0
+  resolution: "tslib@npm:2.6.0"
+  checksum: c01066038f950016a18106ddeca4649b4d76caa76ec5a31e2a26e10586a59fceb4ee45e96719bf6c715648e7c14085a81fee5c62f7e9ebee68e77a5396e5538f
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -420,12 +420,39 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@envelop/parser-cache@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@envelop/parser-cache@npm:6.0.1"
+  dependencies:
+    lru-cache: ^10.0.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@envelop/core": ^4.0.0
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: aa5bbc7f40161df045ef61fe62ba1cb187a5cb4c8456c186f81b1d465b008708276de01bde03d109e8c3ed4a9a9fabe3fb0914302e8c36f4556a9e784a012fd6
+  languageName: node
+  linkType: hard
+
 "@envelop/types@npm:4.0.0":
   version: 4.0.0
   resolution: "@envelop/types@npm:4.0.0"
   dependencies:
     tslib: ^2.5.0
   checksum: cd8bad3ef7d9ee6015e3befbd27a1fb66a560d1397111b0fe22d8a107c7509ab48f183752d514321e35e9c27e9e970e004579867d64105768fce69ccca411ac7
+  languageName: node
+  linkType: hard
+
+"@envelop/validation-cache@npm:^6.0.1":
+  version: 6.0.1
+  resolution: "@envelop/validation-cache@npm:6.0.1"
+  dependencies:
+    hash-it: ^6.0.0
+    lru-cache: ^10.0.0
+    tslib: ^2.5.0
+  peerDependencies:
+    "@envelop/core": ^4.0.0
+    graphql: ^14.0.0 || ^15.0.0 || ^16.0.0
+  checksum: e9c5cdb2edaa8ccf6a730d862d5eb83e0af2772673882a2deb9907f2ef7318d38630ee7ad546ae3bf87648c782bc5b4c424b6cd0a7eac45c3b18c5e0a41f7c29
   languageName: node
   linkType: hard
 
@@ -1348,6 +1375,8 @@ __metadata:
   resolution: "@redwoodjs-stripe/schema@workspace:schema"
   dependencies:
     "@envelop/core": ^4.0.0
+    "@envelop/parser-cache": ^6.0.1
+    "@envelop/validation-cache": ^6.0.1
     graphql: ^16.7.1
   languageName: unknown
   linkType: soft
@@ -3598,6 +3627,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"hash-it@npm:^6.0.0":
+  version: 6.0.0
+  resolution: "hash-it@npm:6.0.0"
+  checksum: 10ca948ff7902a752344c3975c1a5c76ba9e4aa0363032f347a7235cce98473dce60fe4399b05979596aedf649adaf5b3f792a55b9b64ad59ae686e43300c2d1
+  languageName: node
+  linkType: hard
+
 "hosted-git-info@npm:^2.1.4":
   version: 2.8.9
   resolution: "hosted-git-info@npm:2.8.9"
@@ -4965,6 +5001,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"lru-cache@npm:^10.0.0, lru-cache@npm:^9.1.1 || ^10.0.0":
+  version: 10.0.0
+  resolution: "lru-cache@npm:10.0.0"
+  checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^5.1.1":
   version: 5.1.1
   resolution: "lru-cache@npm:5.1.1"
@@ -4994,13 +5037,6 @@ __metadata:
   version: 9.1.2
   resolution: "lru-cache@npm:9.1.2"
   checksum: d3415634be3908909081fc4c56371a8d562d9081eba70543d86871b978702fffd0e9e362b83921b27a29ae2b37b90f55675aad770a54ac83bb3e4de5049d4b15
-  languageName: node
-  linkType: hard
-
-"lru-cache@npm:^9.1.1 || ^10.0.0":
-  version: 10.0.0
-  resolution: "lru-cache@npm:10.0.0"
-  checksum: 18f101675fe283bc09cda0ef1e3cc83781aeb8373b439f086f758d1d91b28730950db785999cd060d3c825a8571c03073e8c14512b6655af2188d623031baf50
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Managing sdl schema is time consuming. Better approach would be to generate schema from Stripe's openAPI Spec. This PR is part one of a larger issue (https://github.com/chrisvdm/redwoodjs-stripe/issues/117)

API (might need some help here):
- github action triggers script to generate a schema from openAPI. 
- script needs a root query OR a list of Stripe Objects as a starting point for the generator.
- Merge generate schema with custom schema (stripeItems)
- schema is saved in sdl file (?) that can be imported into a project


https://github.com/chrisvdm/redwoodjs-stripe/issues/63