### PR TITLE
allow_promotion_codes flag

### DIFF
--- a/api/src/services/checkouts/checkouts.js
+++ b/api/src/services/checkouts/checkouts.js
@@ -18,7 +18,8 @@ export const createStripeCheckoutSession = async ({
   mode,
   cart,
   successUrl = "http://localhost:8910/stripe-demo?success=true&sessionId={CHECKOUT_SESSION_ID}",
-  cancelUrl = "http://localhost:8910/stripe-demo?success=false"
+  cancelUrl = "http://localhost:8910/stripe-demo?success=false",
+  allowPromotionCodes = true
 }) => {
   const line_items = cart.map(product => ({
     price: product.id,
@@ -35,6 +36,7 @@ export const createStripeCheckoutSession = async ({
     line_items: line_items,
     mode: mode,
     payment_method_types: ['card'],
+    allow_promotion_codes: allowPromotionCodes,
     ... (Object.hasOwn(customer, "id") && { customer: customer.id })
   }
 

--- a/web/src/hooks/useStripeCheckout.js
+++ b/web/src/hooks/useStripeCheckout.js
@@ -15,8 +15,9 @@ export const useStripeCheckout = () => {
         $cancelUrl: String
         $customer: StripeCustomerInput
         $mode: StripeCheckoutModeEnum
+        $allowPromotionCodes: Boolean
       ) {
-        checkout(cart: $cart, successUrl: $successUrl, cancelUrl: $cancelUrl, customer: $customer, mode: $mode) {
+        checkout(cart: $cart, successUrl: $successUrl, cancelUrl: $cancelUrl, customer: $customer, mode: $mode, allowPromotionCodes: $allowPromotionCodes) {
           id
           url
         }
@@ -39,7 +40,7 @@ export const useStripeCheckout = () => {
   `
  
   return {
-    checkout: async ({ cart, customer, successUrl, cancelUrl, mode }) => {
+    checkout: async ({ cart, customer, successUrl, cancelUrl, mode, allowPromotionCodes }) => {
       // customer = !!customer ? customer : (await context.waitForCustomer())
       customer = customer || context.customer
       cart = cart || context.cart
@@ -61,6 +62,7 @@ export const useStripeCheckout = () => {
           successUrl: successUrl,
           cancelUrl: cancelUrl,
           mode: determinedMode,
+          allowPromotionCodes: allowPromotionCodes,
           ... (customer != null ? {
             customer: {
               id: customer.id,


### PR DESCRIPTION
Current checkout implementation did not allow the use of allow_promotion_codes in the stripe checkout page. Added the flag as a parameter when creating a checkout session. 