### PR TITLE
Fix sync script

### DIFF
--- a/api/package.json
+++ b/api/package.json
@@ -2,6 +2,12 @@
   "name": "@redwoodjs-stripe/api",
   "version": "1.0.6",
   "description": "API-side code for RedwoodJS-Stripe projects",
+  "exports": {
+    ".": {
+      "redwoodjs-stripe:development": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    }
+  },
   "keywords": [
     "stripe",
     "redwoodjs",
@@ -10,7 +16,7 @@
   ],
   "license": "MIT",
   "author": "chrisvdm",
-  "main": "./dist/index.js",
+  "main": "./dist/cjs/index.js",
   "files": [
     "dist"
   ],

--- a/cli/package.json
+++ b/cli/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@redwoodjs-stripe/cli",
   "version": "1.0.4",
-  "bin": "./dist/cli.js",
+  "bin": "./dist/cjs/cli.js",
   "keywords": [
     "stripe",
     "redwoodjs",

--- a/web/package.json
+++ b/web/package.json
@@ -1,8 +1,16 @@
 {
   "name": "@redwoodjs-stripe/web",
   "version": "1.0.6",
-  "main": "./dist/index.js",
+  "main": "./dist/cjs/index.js",
+  "exports": {
+    ".": {
+      "redwoodjs-stripe:development": "./dist/esm/index.js",
+      "default": "./dist/cjs/index.js"
+    },
+    "./dev-vite-plugin": "./plugins/dev-vite-plugin.js"
+  },
   "files": [
+    "plugins",
     "dist"
   ],
   "keywords": [


### PR DESCRIPTION
Now that redwood uses vite for the web side in dev instead of webpack, we needed to change the way the `yarn sync` script works to be compatible with vite.

This PR adds a vite plugin that tells vite to also look in `node_modules/@redwoodjs-stripe/...` when watching. The plugin is used like this:

```diff
diff --git a/web/vite.config.js b/web/vite.config.js
index 5d77c58..321ae9e 100644
--- a/web/vite.config.js
+++ b/web/vite.config.js
@@ -3,13 +3,14 @@ import dns from 'dns'
 import { defineConfig } from 'vite'
 
 import redwood from '@redwoodjs/vite'
+import redwoodStripe from '@redwoodjs-stripe/web/dev-vite-plugin'
 
 // So that Vite will load on localhost instead of `127.0.0.1`.
 // See: https://vitejs.dev/config/server-options.html#server-host.
 dns.setDefaultResultOrder('verbatim')
 
 const viteConfig = {
-  plugins: [redwood()],
+  plugins: [redwood(), redwoodStripe()],
 }
 
 export default defineConfig(viteConfig)
```

It also builds both cjs and esm outputs for api and web, except we still only use cjs as the module type for both for now. The esm outputs are only used when this vite plugin is enabled.

Once this is merged and released the contribution guide will also be updated to include using this plugin.
