### PR TITLE
fix: Correct null id check in retrieveStripeCustomer

### DIFF
--- a/api/src/services/customers/customers.ts
+++ b/api/src/services/customers/customers.ts
@@ -26,7 +26,7 @@ export const retrieveStripeCustomer = async ({
 }: QueryRetrieveStripeCustomerArgs): Promise<ParsedStripeResponse<Stripe.Customer | Stripe.DeletedCustomer>> => {
   const { id, addProps } = data ?? {};
 
-  if (id !== null) {
+  if (id == null) {
     throw nonNilAssertionError("retrieveStripeCustomer:id", data);
   }
 


### PR DESCRIPTION
It looks like the [retrieveStripeCustomer](https://github.com/chrisvdm/redwoodjs-stripe/blob/d94772efa58f1d9ccac90e3be72240ec5b4e1136/api/src/services/customers/customers.ts#L24-L31) implementation has a small bug where the conditional is flipped. My project is passing in customer ID [similar to the example-store-stripe repo](https://github.com/chrisvdm/redwoodjs-stripe/wiki/API-Reference#user-mapping) like this: 
```
 <StripeProvider customer={{ id: customer }}>
    ...
 </StripeProvider>
```

And eventually results in a call to retrieveStripeCustomer(), which triggers this error:
```
api | [13:13:05.115] ERROR: Unexpectedly received null or undefined data. This may be a bug in redwoodjs-stripe.
api |
api | Please file an issue for it over here, and provide with the details given below: https://github.com/chrisvdm/redwoodjs-stripe/issues/new",
api |
api | **Context:**
api | retrieveStripeCustomer:id
api |
api | **Data:**
api | { id: '<customer_id>', addProps: null }
api |
api |     err: {
api |       "type": "GraphQLError",
api |       "message": "Unexpectedly received null or undefined data. This may be a bug in redwoodjs-stripe.\n\nPlease file an issue for it over here, and provide with the details given below: https://github.com/chrisvdm/redwoodjs-stripe/issues/new\",\n\n**Context:**\nretrieveStripeCustomer:id\n\n**Data:**\n{ id: '<customer_id>', addProps: null }\n",
api |       "stack":
api |           Error: Unexpectedly received null or undefined data. This may be a bug in redwoodjs-stripe.
api |
api |           Please file an issue for it over here, and provide with the details given below: https://github.com/chrisvdm/redwoodjs-stripe/issues/new",
api |
api |           **Context:**
api |           retrieveStripeCustomer:id
api |
api |           **Data:**
api |           { id: '<customer_id>', addProps: null }
api |
api |               at nonNilAssertionError (/Users/matt/workspace/moontower-rwjs/node_modules/@redwoodjs-stripe/api/dist/cjs/lib/nonNilAssertionError.js:25:49)
api |               at Object.retrieveStripeCustomer (/Users/matt/workspace/moontower-rwjs/node_modules/@redwoodjs-stripe/api/dist/cjs/services/customers/customers.js:44:64)
api |               at Object.retrieveStripeCustomer (/Users/matt/workspace/moontower-rwjs/node_modules/@redwoodjs/graphql-server/dist/makeMergedSchema.js:97:30)
api |               at useRedwoodDirectiveValidatorResolver (/Users/matt/workspace/moontower-rwjs/node_modules/@redwoodjs/graphql-server/dist/plugins/useRedwoodDirective.js:82:22)
api |               at executeField (/Users/matt/workspace/moontower-rwjs/node_modules/@graphql-tools/executor/cjs/execution/execute.js:324:24)
api |               at executeFields (/Users/matt/workspace/moontower-rwjs/node_modules/@graphql-tools/executor/cjs/execution/execute.js:272:28)
api |               at executeOperation (/Users/matt/workspace/moontower-rwjs/node_modules/@graphql-tools/executor/cjs/execution/execute.js:232:18)
api |               at /Users/matt/workspace/moontower-rwjs/node_modules/@graphql-tools/executor/cjs/execution/execute.js:69:64
api |               at new ValueOrPromise (/Users/matt/workspace/moontower-rwjs/node_modules/value-or-promise/src/ValueOrPromise.ts:35:15)
api |               at executeImpl (/Users/matt/workspace/moontower-rwjs/node_modules/@graphql-tools/executor/cjs/execution/execute.js:69:20)
api |       "path": [
api |         "retrieveStripeCustomer"
api |       ],
api |       "locations": [
api |         {
api |           "line": 2,
api |           "column": 3
api |         }
api |       ],
api |       "extensions": {}
api |     }
api | [13:13:05.115] DEBUG: Processing GraphQL Parameters done.
api | [13:13:05.116] INFO: request completed
api |     reqId: "req-8"
api |     res: {
api |       "statusCode": 200
api |     }
api |     responseTime: 19.324374988675117
```

Based on the other examples in `customers.ts`, this assertion is meant to catch null values (`== null`). It's currently flipped (`!== null`). If this is the intended behavior, we should use a different assertion. 